### PR TITLE
Fix merged players appearing in tournament lists

### DIFF
--- a/dao.py
+++ b/dao.py
@@ -170,23 +170,19 @@ class Dao(object):
 
         player.name = name
         return self.update_player(player)
-#jiang code
-    def insert_pending_tournament(self, tournament):
-        the_json = tournament.get_json_dict()
-        return self.pending_tournaments_col.insert(the_json)
-
-    def update_pending_tournament(self, tournament):
-        return self.pending_tournaments_col.update({'_id': tournament.id}, tournament.get_json_dict())
-
-    def get_all_pending_tournament_jsons(self, regions=None):
-        query_dict = {'regions': {'$in': regions}} if regions else {}
-        return self.pending_tournaments_col.find(query_dict).sort([('date', 1)])
 
     def insert_pending_tournament(self, pending_tournament):
         return self.pending_tournaments_col.insert(pending_tournament.get_json_dict())
 
+    def update_pending_tournament(self, tournament):
+        return self.pending_tournaments_col.update({'_id': tournament.id}, tournament.get_json_dict())
+
     def delete_pending_tournament(self, pending_tournament):
         return self.pending_tournaments_col.remove({'_id': pending_tournament.id})
+
+    def get_all_pending_tournament_jsons(self, regions=None):
+        query_dict = {'regions': {'$in': regions}} if regions else {}
+        return self.pending_tournaments_col.find(query_dict).sort([('date', 1)])
 
     def get_all_pending_tournaments(self, regions=None):
         '''players is a list of Players'''
@@ -314,7 +310,8 @@ class Dao(object):
         # uniqify
         similar_aliases = list(set(similar_aliases))
 
-        ret = self.players_col.find({'aliases': {'$in': similar_aliases}})
+        ret = self.players_col.find({'aliases': {'$in': similar_aliases},
+                                     'merged': False})
         return [Player.from_json(p) for p in ret]
 
     # inserts and merges players!

--- a/server.py
+++ b/server.py
@@ -692,6 +692,18 @@ class FinalizeTournamentResource(restful.Resource):
             player_id = dao.insert_player(player)
             pending_tournament.set_alias_id_mapping(player_name, player_id)
 
+        # validate players in this tournament
+        for mapping in pending_tournament.alias_to_id_map:
+            try:
+                player_id = mapping["player_id"]
+                # TODO: reduce queries to DB by batching
+                player = dao.get_player_by_id(player_id)
+                if player.merged:
+                    return "Player {} has already been merged".format(player.name), 400
+            except:
+                return "Not all player ids are valid", 400
+
+
         try:
             dao.update_pending_tournament(pending_tournament)
             tournament = Tournament.from_pending_tournament(pending_tournament)


### PR DESCRIPTION
Make sure we don't have tournaments with players who have already been merged.

- check player is not merged when initializing tournament
- don't show merged players in alias suggestion

