### PR TITLE
make TestServer faster by not setting up db every time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ iso8601==0.1.10
 itsdangerous==0.24
 lxml==3.3.5
 mock==1.0.1
-mongomock==2.0.0
+mongomock==3.5.1.dev1
 nose==1.3.4
 oauth2client==1.3.2
 passlib==1.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ iso8601==0.1.10
 itsdangerous==0.24
 lxml==3.3.5
 mock==1.0.1
-mongomock==3.5.1.dev1
+mongomock==3.5.0
 nose==1.3.4
 oauth2client==1.3.2
 passlib==1.6.5


### PR DESCRIPTION
Right now our tests take on the order of 4-6 minutes to run, most of this taken up by the TestServer tests (they also eat tons of memory). Originally the TestServer tests would initialize the db once for every test; this changes it so that it does this once at a beginning and stores a frozen copy in python memory. This speeds up TestServer significantly on my machine locally.