### PR TITLE
remove specific mongomock version from vagrant install script

### DIFF
--- a/scripts/vagrant/project_setup.sh
+++ b/scripts/vagrant/project_setup.sh
@@ -5,7 +5,6 @@ set -e # Exit script immediately on first error.
 
 echo "Installing project dependencies..."
 sudo pip install -r requirements.txt
-sudo pip install git+https://github.com/vmalloc/mongomock.git@master # use master instead of 2.0.0
 
 # NOTE: if config/config.ini.template changes, this needs to change also
 #       the challonge api key is for a throw-away dev account


### PR DESCRIPTION
This seems unnecessary since mongomock version is 3.5.0 in requirements.txt, but let me know if it still is.
https://github.com/ripgarpr/garpr/blob/master/requirements.txt#L23