### PR TITLE
add gpg key for apt repository

### DIFF
--- a/scripts/vagrant/general_setup.sh
+++ b/scripts/vagrant/general_setup.sh
@@ -4,6 +4,7 @@
 set -e # Exit script immediately on first error.
 
 echo "Updating..."
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FF3997E83CD969B409FB24BC5BB92C09DB82666C
 sudo add-apt-repository ppa:fkrull/deadsnakes-python2.7 # get newest version of python 2.7
 sudo apt-get update
 sudo apt-get upgrade -y


### PR DESCRIPTION
The repository has been deprecated, which breaks starting a new vagrant environment since the GPG key is no longer "automatically obtainable"; see https://bitbucket.org/deadsnakes/issues/issues/47/27-packages. This is an easy fix, but should possibly be replaced with something more long-term since the repo is deprecated.

@jschnei 