### PR TITLE
"view match history" opens new tab in alias matching

### DIFF
--- a/webapp/app/tournaments/views/tournament_detail.html
+++ b/webapp/app/tournaments/views/tournament_detail.html
@@ -44,7 +44,7 @@
                         <div ng-hide="playerCheckboxState[player]">
                             <div ng-show="playerData[player].hasOwnProperty('id')">
                                 <p>Regions: <strong>{{prettyPrintRegionListForPlayer(playerData[player])}}</strong></p>
-                                <a href="#/{{regionService.region.id}}/players/{{playerData[player].id}}">
+                                <a href="#/{{regionService.region.id}}/players/{{playerData[player].id}}" target="_blank">
                                     <p>View match history</p>
                                 </a>
                             </div>


### PR DESCRIPTION
Right now it's easy to misclick and lose all alias matching progress. This change prevents that.

@jschnei 